### PR TITLE
[AS-613] Introduce `{{date-diff-in-days}}` helper

### DIFF
--- a/addon/helpers/date-diff-in-days.js
+++ b/addon/helpers/date-diff-in-days.js
@@ -1,0 +1,21 @@
+import { differenceInDays } from 'date-fns';
+import { helper } from '@ember/component/helper';
+import normalizeDate from '../utils/normalize-date';
+
+/**
+  Return the distance between two given dates, as an integer.
+  @param {Date|String|Number} date given date
+  @param {Date|String|Number} baseDate given date
+  @param {String} inputFormat string of tokens
+  @return {Number} difference in days
+*/
+export default helper(function dateDiffInDays([dateA, dateB, inputFormat]) {
+  if (!dateA || !dateB) {
+    return;
+  }
+
+  let normalizedDateA = normalizeDate(dateA, inputFormat);
+  let normalizedDateB = normalizeDate(dateB, inputFormat);
+
+  return Math.abs(differenceInDays(normalizedDateA, normalizedDateB));
+});

--- a/app/helpers/date-diff-in-days.js
+++ b/app/helpers/date-diff-in-days.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  dateDiffInDays,
+} from '@precision-nutrition/ember-date-fns-helpers/helpers/date-diff-in-days';

--- a/index.js
+++ b/index.js
@@ -2,4 +2,8 @@
 
 module.exports = {
   name: require('./package').name,
+
+  isDevelopingAddon() {
+    return false;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@precision-nutrition/ember-date-fns-helpers",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.0",
   "description": "date-fns helpers",
   "keywords": [
     "ember-addon"

--- a/tests/integration/helpers/date-diff-in-days-test.js
+++ b/tests/integration/helpers/date-diff-in-days-test.js
@@ -1,0 +1,73 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { addDays, subDays, format } from 'date-fns';
+
+module('Integration | Helper | date-diff-in-days', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('diff-ing 2 dates', async function (assert) {
+    this.setProperties({
+      dateA: subDays(new Date(), 2),
+      dateB: addDays(new Date(), 2),
+    });
+
+    await render(hbs`{{date-diff-in-days this.dateA this.dateB}}`);
+
+    assert.equal(this.element.textContent.trim(), '4');
+  });
+
+  test('the returned diff is always positive integer, regardless of which date is compared first', async function (assert) {
+    this.setProperties({
+      dateA: subDays(new Date(), 3),
+      dateB: addDays(new Date(), 2),
+    });
+
+    await render(hbs`{{date-diff-in-days this.dateA this.dateB}}`);
+
+    assert.equal(this.element.textContent.trim(), '5');
+
+    await render(hbs`{{date-diff-in-days this.dateB this.dateA}}`);
+
+    assert.equal(this.element.textContent.trim(), '5');
+  });
+
+  test('the two given dates can be ISO strings', async function (assert) {
+    this.setProperties({
+      dateA: subDays(new Date(), 3).toISOString(),
+      dateB: addDays(new Date(), 3).toISOString(),
+    });
+
+    await render(hbs`{{date-diff-in-days this.dateA this.dateB}}`);
+    assert.equal(this.element.textContent.trim(), '6');
+  });
+
+  test('the two given dates can be in string format, if a format string arg is provided', async function (assert) {
+    this.setProperties({
+      dateA: format(subDays(new Date(), 2), 'yyyy-MM-dd'),
+      dateB: format(addDays(new Date(), 5), 'yyyy-MM-dd'),
+    });
+
+    await render(hbs`{{date-diff-in-days this.dateA this.dateB "yyyy-MM-dd"}}`);
+
+    assert.equal(this.element.textContent.trim(), '7');
+  });
+
+  test('the two given dates can be MIXED format, if a format string is OMITTED', async function (assert) {
+    // Hopefully no one in their right mind would want to do this
+    this.setProperties({
+      dateA: '2021-3-4',
+      dateB: new Date(2021, 2, 2),
+    });
+
+    await render(hbs`{{date-diff-in-days this.dateA this.dateB}}`);
+
+    assert.equal(this.element.textContent.trim(), '2');
+  });
+
+  test('renders nothing with no args', async function (assert) {
+    await render(hbs`{{date-diff-in-days}}`);
+    assert.equal(this.element.textContent, '');
+  });
+});


### PR DESCRIPTION
Adds a new helper: `{{date-diff-in-days}}`

Returns an integer, representing "days between two given dates"

This PR supplements, this work: https://github.com/PrecisionNutrition/fitpro/pull/1565