### PR TITLE
[ST-1683] ember-date-fns-helpers - utcOffset() is failing tests

### DIFF
--- a/tests/unit/utils/utc-offset-test.js
+++ b/tests/unit/utils/utc-offset-test.js
@@ -2,18 +2,23 @@ import utcOffset from 'dummy/utils/utc-offset';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | utc-offset', function () {
-  test('it works', function (assert) {
-    const utc0 = 'Europe/London';
-    const utcPos11 = 'Pacific/Niue';
-    const utcNeg4 = 'Asia/Dubai';
-    const utcNeg2 = 'Africa/Bujumbura';
+  test('it works with DST offset shift', function (assert) {
+    const londonOffset = utcOffset('Europe/London');
+    const validLondonOffsets = [-60, 0];
+    const aucklandOffset = utcOffset('Pacific/Auckland');
+    const validAucklandOffsets = [-780, -720];
 
-    assert.equal(utcOffset(utc0), 0, 'works for Europe/London');
+    assert.ok(validLondonOffsets.includes(londonOffset), 'works for Europe/London DST');
+    assert.ok(validAucklandOffsets.includes(aucklandOffset), 'works for Pacific/Auckland');
+  });
 
-    assert.equal(utcOffset(utcPos11), 660, 'works for Pacific/Niue');
+  test('it works with non-DST countries', function (assert) {
+    const niue = utcOffset('Pacific/Niue');
+    const dubai = utcOffset('Asia/Dubai');
+    const bujumbura = utcOffset('Africa/Bujumbura');
 
-    assert.equal(utcOffset(utcNeg4), -240, 'works for Asia/Dubai');
-
-    assert.equal(utcOffset(utcNeg2), -120, 'works for Africa/Bujumbura');
+    assert.equal(niue, 660, 'works for Pacific/Niue');
+    assert.equal(dubai, -240, 'works for Asia/Dubai');
+    assert.equal(bujumbura, -120, 'works for Africa/Bujumbura');
   });
 });


### PR DESCRIPTION
What changed & why
===============

`utcOffset()` util appears to be working just fine

However, due to Daylight Savings Time in different timezones, the function my return a different value.

For instance, London may be `UTC 0` or `UTC +1` depending on the time of year.

Therefore, I decided that the unit test should be asserting _either_ `0` or `-60`, since there is no clean way to determine when DST is in effect during the time the test runs.