### PR TITLE
[ST-1702] {{date-diff needs "year" precision

### DIFF
--- a/addon/helpers/date-diff.js
+++ b/addon/helpers/date-diff.js
@@ -7,7 +7,6 @@ import {
   differenceInSeconds,
 } from 'date-fns';
 import normalizeDate from '../utils/normalize-date';
-import { assert } from '@ember/debug';
 
 /**
   Return the difference between two given dates as a number.
@@ -21,11 +20,6 @@ import { assert } from '@ember/debug';
 */
 export default helper(function dateDiff([dateA, dateB], { precision = 'days', inputFormat }) {
   if (!dateA || !dateB) return null;
-
-  assert(
-    '{{date-diff helper should not accept date args of mixed type',
-    typeof dateA === typeof dateB
-  );
 
   const normalizedDateA = normalizeDate(dateA, inputFormat);
   const normalizedDateB = normalizeDate(dateB, inputFormat);

--- a/addon/helpers/date-diff.js
+++ b/addon/helpers/date-diff.js
@@ -7,6 +7,8 @@ import {
   differenceInSeconds,
 } from 'date-fns';
 import normalizeDate from '../utils/normalize-date';
+import { typeOf } from '@ember/utils';
+import { deprecate } from '@ember/debug';
 
 /**
   Return the difference between two given dates as a number.
@@ -20,6 +22,18 @@ import normalizeDate from '../utils/normalize-date';
 */
 export default helper(function dateDiff([dateA, dateB], { precision = 'days', inputFormat }) {
   if (!dateA || !dateB) return null;
+
+  deprecate(
+    `{{date-diff date args should be matching type, you passed '${typeOf(dateA)}' and '${typeOf(
+      dateB
+    )}'`,
+    typeOf(dateA) === typeOf(dateB),
+    {
+      id: 'date-diff/avoid-mixed-date-types',
+      until: '1.0.0',
+      for: '@precision-nutrition/ember-date-fns-helpers',
+    }
+  );
 
   const normalizedDateA = normalizeDate(dateA, inputFormat);
   const normalizedDateB = normalizeDate(dateB, inputFormat);

--- a/addon/helpers/date-diff.js
+++ b/addon/helpers/date-diff.js
@@ -1,5 +1,6 @@
 import { helper } from '@ember/component/helper';
 import {
+  differenceInYears,
   differenceInDays,
   differenceInHours,
   differenceInMinutes,
@@ -32,6 +33,9 @@ export default helper(function dateDiff([dateA, dateB], { precision = 'days', in
   let difference;
 
   switch (precision) {
+    case 'years':
+      difference = differenceInYears(normalizedDateA, normalizedDateB);
+      break;
     case 'days':
       difference = differenceInDays(normalizedDateA, normalizedDateB);
       break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@precision-nutrition/ember-date-fns-helpers",
-  "version": "0.5.1-rc.0",
+  "version": "0.5.1-rc.1",
   "description": "date-fns helpers",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@precision-nutrition/ember-date-fns-helpers",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.0",
   "description": "date-fns helpers",
   "keywords": [
     "ember-addon"

--- a/tests/integration/helpers/date-diff-test.js
+++ b/tests/integration/helpers/date-diff-test.js
@@ -58,7 +58,12 @@ module('Integration | Helper | date-diff', function (hooks) {
     this.setProperties({
       dateA: new Date(),
       dateB: addDays(new Date(), 1),
+      dateC: addDays(new Date(), 730),
     });
+
+    await render(hbs`{{date-diff this.dateA this.dateC precision="years"}}`);
+
+    assert.equal(this.element.textContent.trim(), '2');
 
     await render(hbs`{{date-diff this.dateA this.dateB precision="days"}}`);
 
@@ -78,7 +83,7 @@ module('Integration | Helper | date-diff', function (hooks) {
 
     await render(hbs`{{date-diff this.dateA this.dateB precision="foobars"}}`);
 
-    assert.equal(this.element.textContent.trim(), '1');
+    assert.equal(this.element.textContent.trim(), '1', 'default is in "days"');
   });
 
   test('renders nothing with no args', async function (assert) {


### PR DESCRIPTION
We need "years" precision in order to fully replace `{{moment-diff` for our usages.

Also, I needed to roll back on the ["date types must match"](https://github.com/PrecisionNutrition/ember-date-fns-helpers/blob/master/addon/helpers/date-diff.js#L24-L27) scenario for this helper... Reason being is that Fitpro in particular, uses too many different date types.. and also there are a few cases where the dates/models are lazy-loaded, causing pre-mature failures in tests.

Test it here: https://github.com/PrecisionNutrition/fitpro/pull/1571