### PR TITLE
Refactor `{{date-format`

### DIFF
--- a/addon/helpers/date-format.js
+++ b/addon/helpers/date-format.js
@@ -1,7 +1,7 @@
+import Helper from '@ember/component/helper';
 import { format, utcToZonedTime } from 'date-fns-tz';
-import { helper } from '@ember/component/helper';
 import normalizeDate from '../utils/normalize-date';
-import config from 'ember-get-config';
+import { getOwner } from '@ember/application';
 
 /**
   Return the formatted date string in the given format.
@@ -11,17 +11,25 @@ import config from 'ember-get-config';
   @param {Object} options object with options
   @return {String} formatted date string
 */
-export default helper(function dateFormat([date, outputFormat, inputFormat], options = {}) {
-  if (!date) {
-    return;
+export default class DateFormat extends Helper {
+  get defaultOutputFormat() {
+    const config = getOwner(this).resolveRegistration('config:environment');
+
+    return config.date.outputFormat;
   }
 
-  let normalizedDate = normalizeDate(date, inputFormat);
-  let outFormat = outputFormat || config.date.outputFormat;
+  compute([date, outputFormat, inputFormat], options = {}) {
+    if (!date) {
+      return;
+    }
 
-  if (options.timeZone) {
-    normalizedDate = utcToZonedTime(normalizedDate, options.timeZone);
+    let normalizedDate = normalizeDate(date, inputFormat);
+    const outFormat = outputFormat || this.defaultOutputFormat;
+
+    if (options.timeZone) {
+      normalizedDate = utcToZonedTime(normalizedDate, options.timeZone);
+    }
+
+    return format(normalizedDate, outFormat, options);
   }
-
-  return format(normalizedDate, outFormat, options);
-});
+}

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "date-fns-tz": "^1.1.4",
     "ember-auto-import": "^1.10.1",
     "ember-cli-babel": "^7.23.0",
-    "ember-cli-htmlbars": "^5.3.1",
-    "ember-get-config": "^0.2.4"
+    "ember-cli-htmlbars": "^5.3.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,14 +3737,6 @@ broccoli-debug@^0.6.4, broccoli-debug@^0.6.5:
     symlink-or-copy "^1.1.8"
     tree-sync "^1.2.2"
 
-broccoli-file-creator@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.2.0.tgz#27f1b25b1b00e7bb7bf3d5d7abed5f4d5388df4d"
-  integrity sha512-l9zthHg6bAtnOfRr/ieZ1srRQEsufMZID7xGYRW3aBDv3u/3Eux+Iawl10tAGYE5pL9YB4n5X4vxkp6iNOoZ9g==
-  dependencies:
-    broccoli-plugin "^1.1.0"
-    mkdirp "^0.5.1"
-
 broccoli-file-creator@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
@@ -5411,7 +5403,7 @@ ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.3.0:
+ember-cli-babel@^6.0.0-beta.4:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -5829,14 +5821,6 @@ ember-export-application-global@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
-
-ember-get-config@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
-  integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=
-  dependencies:
-    broccoli-file-creator "^1.1.1"
-    ember-cli-babel "^6.3.0"
 
 ember-load-initializers@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
By using a class-based helper we can completely eliminate our need of
the ember-get-config package.
